### PR TITLE
Make info trace a debug instead

### DIFF
--- a/crates/gitbutler-branch-actions/src/branch.rs
+++ b/crates/gitbutler-branch-actions/src/branch.rs
@@ -28,7 +28,7 @@ use std::{
     vec,
 };
 use tracing::instrument;
-
+//fsdlkj
 #[instrument(level = tracing::Level::DEBUG, skip(ctx, _permission))]
 pub(crate) fn get_uncommited_files_raw(
     ctx: &CommandContext,


### PR DESCRIPTION


<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #57 
- <kbd>&nbsp;1&nbsp;</kbd> #54 👈 
<!-- GitButler Footer Boundary Bottom -->

