### PR TITLE
docs: mention Arch Linux is a supported distribution

### DIFF
--- a/LINUX.md
+++ b/LINUX.md
@@ -33,7 +33,7 @@ There are several community-maintained distributions of GitButler. Issues with t
 
 > Know of one we missed? Submit a PR to keep us in the loop!
 
-- Arch Linux User Repository (AUR)
+- Arch Linux User Repository (AUR) — Arch Linux is a supported distribution
   - [gitbutler](https://aur.archlinux.org/packages/gitbutler)
   - [gitbutler-bin](https://aur.archlinux.org/packages/gitbutler-bin)
 - Flatpak


### PR DESCRIPTION
## Summary
- Updated LINUX.md to explicitly note that Arch Linux is a supported distribution via AUR packages

## Test plan
- [x] Verify the change renders correctly in markdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)