### PR TITLE
docs: mention Arch Linux as supported

### DIFF
--- a/LINUX.md
+++ b/LINUX.md
@@ -27,6 +27,10 @@ We provide an experimental AppImage that bundles the core dependencies required 
 
 The AppImage may be removed in the future if compatibility remains poor.
 
+## Experimentally supported: Arch Linux
+
+GitButler is known to work on Arch Linux. While not officially tested as part of the development process, Arch is a supported platform and compatibility issues are welcome in the [issue tracker](https://github.com/gitbutlerapp/gitbutler/issues). Community-maintained AUR packages are available (see below).
+
 ## Community-maintained distributions
 
 There are several community-maintained distributions of GitButler. Issues with these distributions should typically be brought to the attention of their respective maintainers.


### PR DESCRIPTION
## Summary
- Adds an "Experimentally supported: Arch Linux" section to LINUX.md noting that Arch is a known working platform with community AUR packages available.

## Test plan
- [x] Verify LINUX.md renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)